### PR TITLE
Fix signature for canonicalized extension headers

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -307,7 +307,10 @@ describe Google::Cloud::Storage::File, :storage do
     http = Net::HTTP.new uri.host, uri.port
     http.use_ssl = true
     http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
+
     resp = http.get uri.request_uri
+    resp.code.must_equal "200"
+
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       tmpfile.write resp.body
@@ -329,7 +332,10 @@ describe Google::Cloud::Storage::File, :storage do
     http = Net::HTTP.new uri.host, uri.port
     http.use_ssl = true
     http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
+
     resp = http.get uri.request_uri
+    resp.code.must_equal "200"
+
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       tmpfile.write resp.body
@@ -350,8 +356,8 @@ describe Google::Cloud::Storage::File, :storage do
     http = Net::HTTP.new uri.host, uri.port
     http.use_ssl = true
     http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
-    resp = http.delete uri.request_uri
 
+    resp = http.delete uri.request_uri
     resp.code.must_equal "204"
   end
 
@@ -361,13 +367,18 @@ describe Google::Cloud::Storage::File, :storage do
 
     five_min_from_now = 5 * 60
     url = file.signed_url method: "GET",
-                          headers: {"x-goog-acl" => "public-read"}
+                          headers: { "X-Goog-META-Foo" => "bar,baz",
+                                     "X-Goog-ACL" => "public-read" }
 
     uri = URI url
     http = Net::HTTP.new uri.host, uri.port
     http.use_ssl = true
     http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
-    resp = http.get uri.request_uri
+
+    resp = http.get uri.request_uri, { "X-Goog-meta-foo" => "bar,baz",
+                                       "X-Goog-ACL" => "public-read" }
+    resp.code.must_equal "200"
+
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       tmpfile.write resp.body

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -771,7 +771,7 @@ module Google
           def signature_str options
             [options[:method], options[:content_md5],
              options[:content_type], options[:expires],
-             ext_path].join "\n"
+             format_extension_headers(options[:headers]) + ext_path].join "\n"
           end
 
           def determine_signing_key options = {}
@@ -805,19 +805,18 @@ module Google
 
           def generate_signed_url issuer, signed_string, expires, headers = nil
             signature = Base64.strict_encode64(signed_string).delete("\n")
-            url = "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
-                      "&Expires=#{expires}" \
-                      "&Signature=#{CGI.escape signature}"
-            url += "&Canonicalized_Extension_Headers=#{format_extension_headers(headers)}" if headers
-            url
+            "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
+              "&Expires=#{expires}" \
+              "&Signature=#{CGI.escape signature}"
           end
 
-          def format_extension_headers(headers)
-            flatten = headers.each_with_object({}) {|(key, value), obj| obj[key.to_s.strip] = value.gsub(/\s+/, ' ') }
-            flatten.delete("x-goog-encryption-key")
-            flatten.delete("x-goog-encryption-key-sha256")
-
-            flatten.map {|key, value| "#{key}:#{value}"}.join("\n")
+          def format_extension_headers headers
+            return "" if headers.nil?
+            raise "Headers must be given in a Hash" unless headers.is_a? Hash
+            flatten = headers.map do |key, value|
+              "#{key.to_s.downcase}:#{value.gsub /\s+/, ' '}\n"
+            end.delete_if { |h| h.start_with? "x-goog-encryption-key" }
+            flatten.sort.join
           end
         end
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_test.rb
@@ -24,56 +24,80 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
   let(:file_path) { "file.ext" }
 
   it "uses the credentials' issuer and signing_key to generate signed_url" do
-    signing_key_mock = Minitest::Mock.new
-    signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, String]
-    credentials.issuer = "native_client_email"
-    credentials.signing_key = signing_key_mock
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
 
-    signed_url = bucket.signed_url file_path
+      signed_url = bucket.signed_url file_path
 
-    signed_url_params = CGI::parse(URI(signed_url).query)
-    signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-    signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
-    signing_key_mock.verify
+      signing_key_mock.verify
+    end
   end
 
   it "allows issuer and signing_key to be passed in as options" do
-    credentials.issuer = "native_client_email"
-    credentials.signing_key = PoisonSigningKey.new
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = PoisonSigningKey.new
 
-    signing_key_mock = Minitest::Mock.new
-    signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, String]
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
 
-    signed_url = bucket.signed_url file_path, issuer: "option_issuer",
-                                              signing_key: signing_key_mock
+      signed_url = bucket.signed_url file_path, issuer: "option_issuer",
+                                                signing_key: signing_key_mock
 
-    signed_url_params = CGI::parse(URI(signed_url).query)
-    signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-    signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
-    signing_key_mock.verify
+      signing_key_mock.verify
+    end
   end
 
   it "allows client_email and private to be passed in as options" do
-    credentials.issuer = "native_client_email"
-    credentials.signing_key = PoisonSigningKey.new
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = PoisonSigningKey.new
 
-    signing_key_mock = Minitest::Mock.new
-    signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, String]
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
 
-    OpenSSL::PKey::RSA.stub :new, signing_key_mock do
+      OpenSSL::PKey::RSA.stub :new, signing_key_mock do
 
-      signed_url = bucket.signed_url file_path, client_email: "option_client_email",
-                                                private_key: "option_private_key"
+        signed_url = bucket.signed_url file_path, client_email: "option_client_email",
+                                                  private_key: "option_private_key"
+
+        signed_url_params = CGI::parse(URI(signed_url).query)
+        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
+        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+
+      end
+
+      signing_key_mock.verify
+    end
+  end
+
+  it "allows headers to be passed in as options" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\nx-goog-acl:public-read\nx-goog-meta-foo:bar,baz\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
+
+      signed_url = bucket.signed_url file_path, headers: { "X-Goog-Meta-FOO" => "bar,baz",
+                                                           "X-Goog-ACL" => "public-read" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
+      signing_key_mock.verify
     end
-
-    signing_key_mock.verify
   end
 
   it "raises when missing issuer" do
@@ -98,21 +122,23 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
     let(:file_path) { "hello world.txt" }
 
     it "properly escapes the path when generating signed_url" do
-      signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, String]
-      credentials.issuer = "native_client_email"
-      credentials.signing_key = signing_key_mock
+      Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+        signing_key_mock = Minitest::Mock.new
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
+        credentials.issuer = "native_client_email"
+        credentials.signing_key = signing_key_mock
 
-      signed_url = bucket.signed_url file_path
+        signed_url = bucket.signed_url file_path
 
-      signed_uri = URI signed_url
-      signed_uri.path.must_equal "/bucket/hello%20world.txt"
+        signed_uri = URI signed_url
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
 
-      signed_url_params = CGI::parse signed_uri.query
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        signed_url_params = CGI::parse signed_uri.query
+        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
-      signing_key_mock.verify
+        signing_key_mock.verify
+      end
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
@@ -26,56 +26,80 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
 
   it "uses the credentials' issuer and signing_key to generate signed_url" do
-    signing_key_mock = Minitest::Mock.new
-    signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, String]
-    credentials.issuer = "native_client_email"
-    credentials.signing_key = signing_key_mock
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
 
-    signed_url = file.signed_url
+      signed_url = file.signed_url
 
-    signed_url_params = CGI::parse(URI(signed_url).query)
-    signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-    signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
-    signing_key_mock.verify
+      signing_key_mock.verify
+    end
   end
 
   it "allows issuer and signing_key to be passed in as options" do
-    credentials.issuer = "native_client_email"
-    credentials.signing_key = PoisonSigningKey.new
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = PoisonSigningKey.new
 
-    signing_key_mock = Minitest::Mock.new
-    signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, String]
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
 
-    signed_url = file.signed_url issuer: "option_issuer",
-                                 signing_key: signing_key_mock
+      signed_url = file.signed_url issuer: "option_issuer",
+                                   signing_key: signing_key_mock
 
-    signed_url_params = CGI::parse(URI(signed_url).query)
-    signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-    signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
-    signing_key_mock.verify
+      signing_key_mock.verify
+    end
   end
 
   it "allows client_email and private to be passed in as options" do
-    credentials.issuer = "native_client_email"
-    credentials.signing_key = PoisonSigningKey.new
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = PoisonSigningKey.new
 
-    signing_key_mock = Minitest::Mock.new
-    signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, String]
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
 
-    OpenSSL::PKey::RSA.stub :new, signing_key_mock do
+      OpenSSL::PKey::RSA.stub :new, signing_key_mock do
 
-      signed_url = file.signed_url client_email: "option_client_email",
-                                   private_key: "option_private_key"
+        signed_url = file.signed_url client_email: "option_client_email",
+                                     private_key: "option_private_key"
+
+        signed_url_params = CGI::parse(URI(signed_url).query)
+        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
+        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+
+      end
+
+      signing_key_mock.verify
+    end
+  end
+
+  it "allows headers to be passed in as options" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\nx-goog-acl:public-read\nx-goog-meta-foo:bar,baz\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
+
+      signed_url = file.signed_url headers: { "X-Goog-Meta-FOO" => "bar,baz",
+                                              "X-Goog-ACL" => "public-read" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
+      signing_key_mock.verify
     end
-
-    signing_key_mock.verify
   end
 
   it "raises when missing issuer" do
@@ -100,21 +124,23 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
     let(:file_name) { "hello world.txt" }
 
     it "properly escapes the path when generating signed_url" do
-      signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, String]
-      credentials.issuer = "native_client_email"
-      credentials.signing_key = signing_key_mock
+      Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+        signing_key_mock = Minitest::Mock.new
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
+        credentials.issuer = "native_client_email"
+        credentials.signing_key = signing_key_mock
 
-      signed_url = file.signed_url
+        signed_url = file.signed_url
 
-      signed_uri = URI signed_url
-      signed_uri.path.must_equal "/bucket/hello%20world.txt"
+        signed_uri = URI signed_url
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
 
-      signed_url_params = CGI::parse signed_uri.query
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        signed_url_params = CGI::parse signed_uri.query
+        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
-      signing_key_mock.verify
+        signing_key_mock.verify
+      end
     end
   end
 


### PR DESCRIPTION
Hey @calavera, I found some issues with the implementation in GoogleCloudPlatform/google-cloud-ruby#1127, and in the process of working through it I ended up with enough code that I figured I would just add a commit to your PR. Unfortunately, I don't have access to your repo. Did you check the "Allow edits from maintainers" option?

The fix is pretty straightforward. The headers need to be sorted and downcased. The headers are to be used in the signature hash and not added to the URL query parameters.